### PR TITLE
fix: surface mid-stream SSE error events across all providers (#17)

### DIFF
--- a/.munitor.yml
+++ b/.munitor.yml
@@ -18,6 +18,6 @@ test:
     # vitest threshold ever gets misconfigured. Ratchet up alongside
     # vitest.config.ts thresholds.
     summary_path: coverage/coverage-summary.json
-    min_instruction: "82"
+    min_instruction: "90"
 contexts:
   github: github

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -100,7 +100,9 @@ export class AnthropicProvider implements LLMService {
         return await this.completeStreaming(request, apiKey);
       } catch (e) {
         if (e instanceof Error && e.name === "AbortError") throw e;
+        if (e instanceof Error && e.name === "TimeoutError") throw e;
         if (e instanceof Error && e.message.startsWith("Anthropic API error")) throw e;
+        if (e instanceof Error && e.message.startsWith("Anthropic streaming error")) throw e;
         // Transport-level failure (rare with Node https) -- fall through.
       }
     }
@@ -183,6 +185,10 @@ export class AnthropicProvider implements LLMService {
     const textParts: string[] = [];
     let inputTokens = 0;
     let outputTokens = 0;
+    // Captured by the SSE parser when an upstream `error` event arrives.
+    // Thrown after streamRequest resolves so the partial textParts cannot
+    // be returned as a "successful" CompletionResponse.
+    let streamError: Error | null = null;
 
     const result = await streamRequest({
       url: ANTHROPIC_API_URL,
@@ -204,6 +210,15 @@ export class AnthropicProvider implements LLMService {
 
           try {
             const event = JSON.parse(data);
+
+            // Upstream error event -- captured for throw after the stream ends.
+            // Anthropic shape: { type: "error", error: { type, message } }
+            if (event.type === "error") {
+              const errType = event.error?.type ?? "error";
+              const errMsg = event.error?.message ?? "unknown error";
+              streamError = new Error(`Anthropic streaming error [${errType}]: ${errMsg}`);
+              continue;
+            }
 
             // Text delta -- the main output
             if (event.type === "content_block_delta" && event.delta?.type === "text_delta") {
@@ -227,6 +242,10 @@ export class AnthropicProvider implements LLMService {
         }
       },
     });
+
+    // Upstream emitted an `error` SSE event mid-stream; surface it instead
+    // of returning the partial pre-error tokens as a successful result.
+    if (streamError) throw streamError;
 
     // streamRequest returns non-2xx as data (not an error); inspect status here.
     if (result.status < 200 || result.status >= 300) {

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -78,7 +78,9 @@ export class GoogleProvider implements LLMService {
         return await this.completeStreaming(request, apiKey);
       } catch (e) {
         if (e instanceof Error && e.name === "AbortError") throw e;
+        if (e instanceof Error && e.name === "TimeoutError") throw e;
         if (e instanceof Error && e.message.startsWith("Google API error")) throw e;
+        if (e instanceof Error && e.message.startsWith("Google streaming error")) throw e;
         // Transport-level failure -- fall through to httpFn.
       }
     }
@@ -139,6 +141,8 @@ export class GoogleProvider implements LLMService {
 
     let buffer = "";
     const textParts: string[] = [];
+    // Captured by the SSE parser when an upstream `error` event arrives.
+    let streamError: Error | null = null;
 
     const result = await streamRequest({
       url,
@@ -157,6 +161,13 @@ export class GoogleProvider implements LLMService {
           const data = line.slice(6).trim();
           try {
             const event = JSON.parse(data);
+            // Upstream error event. Google shape: { error: { code, message, status } }
+            if (event.error) {
+              const errStatus = event.error?.status ?? event.error?.code ?? "error";
+              const errMsg = event.error?.message ?? String(event.error);
+              streamError = new Error(`Google streaming error [${errStatus}]: ${errMsg}`);
+              continue;
+            }
             const parts = event.candidates?.[0]?.content?.parts;
             if (Array.isArray(parts)) {
               for (const part of parts) {
@@ -170,6 +181,8 @@ export class GoogleProvider implements LLMService {
         }
       },
     });
+
+    if (streamError) throw streamError;
 
     if (result.status < 200 || result.status >= 300) {
       throw this.buildHttpError(result.status, result.fullText);

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -108,7 +108,9 @@ export class OllamaProvider implements LLMService {
         return await this.completeStreaming(request, endpoint);
       } catch (e) {
         if (e instanceof Error && e.name === "AbortError") throw e;
+        if (e instanceof Error && e.name === "TimeoutError") throw e;
         if (e instanceof Error && e.message.startsWith("Ollama error")) throw e;
+        if (e instanceof Error && e.message.startsWith("Ollama streaming error")) throw e;
         // Transport-level failure (ECONNREFUSED, etc.) -- fall through to httpFn,
         // which will produce the usual "Is Ollama running?" diagnostic.
       }
@@ -178,6 +180,8 @@ export class OllamaProvider implements LLMService {
 
     let buffer = "";
     const textParts: string[] = [];
+    // Captured by the SSE parser when an upstream `error` event arrives.
+    let streamError: Error | null = null;
 
     const result = await streamRequest({
       url: `${endpoint}/v1/chat/completions`,
@@ -197,6 +201,22 @@ export class OllamaProvider implements LLMService {
           if (data === "[DONE]") continue;
           try {
             const event = JSON.parse(data);
+            // Ollama emits errors in two shapes:
+            //   { "error": "context deadline exceeded" }     -- bare string
+            //   { "error": { "message": "...", "type": "..." } } -- OpenAI-compat object
+            if (event.error) {
+              let errMsg: string;
+              let errType: string;
+              if (typeof event.error === "string") {
+                errMsg = event.error;
+                errType = "error";
+              } else {
+                errMsg = event.error?.message ?? String(event.error);
+                errType = event.error?.type ?? "error";
+              }
+              streamError = new Error(`Ollama streaming error [${errType}]: ${errMsg}`);
+              continue;
+            }
             const delta = event.choices?.[0]?.delta?.content;
             if (typeof delta === "string") {
               textParts.push(delta);
@@ -206,6 +226,8 @@ export class OllamaProvider implements LLMService {
         }
       },
     });
+
+    if (streamError) throw streamError;
 
     if (result.status < 200 || result.status >= 300) {
       throw this.buildHttpError(result.status, result.fullText, endpoint);

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -89,7 +89,9 @@ export class OpenAIProvider implements LLMService {
         return await this.completeStreaming(request, apiKey);
       } catch (e) {
         if (e instanceof Error && e.name === "AbortError") throw e;
+        if (e instanceof Error && e.name === "TimeoutError") throw e;
         if (e instanceof Error && e.message.startsWith("OpenAI API error")) throw e;
+        if (e instanceof Error && e.message.startsWith("OpenAI streaming error")) throw e;
         // Transport-level failure -- fall through to httpFn.
       }
     }
@@ -139,6 +141,10 @@ export class OpenAIProvider implements LLMService {
 
     let buffer = "";
     const textParts: string[] = [];
+    // Captured by the SSE parser when an upstream `error` event arrives.
+    // Thrown after streamRequest resolves so partial pre-error tokens can't
+    // surface as a successful CompletionResponse.
+    let streamError: Error | null = null;
 
     const result = await streamRequest({
       url: OPENAI_API_URL,
@@ -158,6 +164,13 @@ export class OpenAIProvider implements LLMService {
           if (data === "[DONE]") continue;
           try {
             const event = JSON.parse(data);
+            // Upstream error event. OpenAI shape: { error: { message, type, ... } }
+            if (event.error) {
+              const errType = event.error?.type ?? "error";
+              const errMsg = event.error?.message ?? String(event.error);
+              streamError = new Error(`OpenAI streaming error [${errType}]: ${errMsg}`);
+              continue;
+            }
             const delta = event.choices?.[0]?.delta?.content;
             if (typeof delta === "string") {
               textParts.push(delta);
@@ -167,6 +180,8 @@ export class OpenAIProvider implements LLMService {
         }
       },
     });
+
+    if (streamError) throw streamError;
 
     if (result.status < 200 || result.status >= 300) {
       throw this.buildHttpError(result.status, result.fullText);

--- a/test/providers/streaming-errors.test.ts
+++ b/test/providers/streaming-errors.test.ts
@@ -1,0 +1,253 @@
+/**
+ * PENNY - Per-Provider Streaming SSE Error Event Tests (#17)
+ *
+ * Verifies that each provider's streaming path detects mid-stream `error`
+ * events and rejects the completion with a descriptive error, instead of
+ * silently swallowing them and returning empty text.
+ *
+ * Mocks `streamRequest` so we can feed pre-canned SSE chunks directly to the
+ * provider's onChunk callback, avoiding the need to stand up a real test
+ * server with provider-specific URL routing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/providers/node-stream", () => {
+  return {
+    streamRequest: vi.fn(),
+    // Pass-through: tests don't exercise the timeout helper here
+    withTimeout: <T>(p: Promise<T>) => p,
+  };
+});
+
+import { streamRequest } from "../../src/providers/node-stream";
+import { AnthropicProvider } from "../../src/providers/anthropic";
+import { OpenAIProvider } from "../../src/providers/openai";
+import { GoogleProvider } from "../../src/providers/google";
+import { OllamaProvider } from "../../src/providers/ollama";
+import type { HttpFn } from "../../src/providers/service";
+
+const stubHttp: HttpFn = async () => ({ status: 200, headers: {}, text: "{}", json: {} });
+const mockStream = vi.mocked(streamRequest);
+
+beforeEach(() => {
+  mockStream.mockReset();
+});
+
+/** Convenience: program the mock to feed a sequence of SSE-formatted chunks. */
+function programChunks(chunks: string[]): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockStream.mockImplementation(async (opts: any) => {
+    for (const chunk of chunks) {
+      opts.onChunk(chunk);
+    }
+    return { status: 200, fullText: chunks.join("") };
+  });
+}
+
+describe("Anthropic streaming — SSE error events", () => {
+  it("rejects with upstream message when an error event is received mid-stream", async () => {
+    programChunks([
+      'data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}\n\n',
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello "}}\n\n',
+      'data: {"type":"error","error":{"type":"overloaded_error","message":"Server is currently overloaded"}}\n\n',
+    ]);
+
+    const provider = new AnthropicProvider(stubHttp);
+    const tokens: string[] = [];
+
+    await expect(
+      provider.complete({
+        systemPrompt: "s",
+        userPrompt: "u",
+        model: "claude-sonnet-4-6",
+        maxTokens: 100,
+        apiKey: "mock-anthropic-test",
+        onToken: (t) => tokens.push(t),
+      }),
+    ).rejects.toThrow(/Server is currently overloaded/);
+  });
+
+  it("does NOT silently include pre-error tokens in a successful result", async () => {
+    programChunks([
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello "}}\n\n',
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"there"}}\n\n',
+      'data: {"type":"error","error":{"type":"api_error","message":"Internal failure"}}\n\n',
+    ]);
+
+    const provider = new AnthropicProvider(stubHttp);
+    const result = await provider.complete({
+      systemPrompt: "s",
+      userPrompt: "u",
+      model: "claude-sonnet-4-6",
+      maxTokens: 100,
+      apiKey: "mock-anthropic-test",
+      onToken: () => { /* ignore */ },
+    }).catch((e) => e);
+
+    // Should be a thrown Error, not a CompletionResponse
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toMatch(/Internal failure/);
+    // The function rejected — caller has no way to access the partial text
+    expect("text" in (result as object)).toBe(false);
+  });
+
+  it("includes the error type in the thrown message", async () => {
+    programChunks([
+      'data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n',
+    ]);
+
+    const provider = new AnthropicProvider(stubHttp);
+    await expect(
+      provider.complete({
+        systemPrompt: "s",
+        userPrompt: "u",
+        model: "claude-sonnet-4-6",
+        maxTokens: 100,
+        apiKey: "mock-anthropic-test",
+        onToken: () => { /* required to take streaming path */ },
+      }),
+    ).rejects.toThrow(/overloaded_error/);
+  });
+});
+
+describe("OpenAI streaming — SSE error events", () => {
+  it("rejects when an error chunk is received mid-stream", async () => {
+    programChunks([
+      'data: {"choices":[{"delta":{"content":"Hello "}}]}\n\n',
+      'data: {"error":{"message":"Rate limit exceeded","type":"rate_limit_exceeded"}}\n\n',
+    ]);
+
+    const provider = new OpenAIProvider(stubHttp);
+    await expect(
+      provider.complete({
+        systemPrompt: "s",
+        userPrompt: "u",
+        model: "gpt-4.1",
+        maxTokens: 100,
+        apiKey: "mock-openai-test",
+        onToken: () => { /* ignore */ },
+      }),
+    ).rejects.toThrow(/Rate limit exceeded/);
+  });
+
+  it("does NOT silently include pre-error tokens", async () => {
+    programChunks([
+      'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n',
+      'data: {"error":{"message":"Service unavailable"}}\n\n',
+    ]);
+
+    const provider = new OpenAIProvider(stubHttp);
+    const result = await provider.complete({
+      systemPrompt: "s",
+      userPrompt: "u",
+      model: "gpt-4.1",
+      maxTokens: 100,
+      apiKey: "mock-openai-test",
+      onToken: () => { /* ignore */ },
+    }).catch((e) => e);
+
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toMatch(/Service unavailable/);
+  });
+});
+
+describe("Google streaming — SSE error events", () => {
+  it("rejects when an error chunk is received mid-stream", async () => {
+    programChunks([
+      'data: {"candidates":[{"content":{"parts":[{"text":"Some "}]}}]}\n\n',
+      'data: {"error":{"code":429,"message":"Resource exhausted","status":"RESOURCE_EXHAUSTED"}}\n\n',
+    ]);
+
+    const provider = new GoogleProvider(stubHttp);
+    await expect(
+      provider.complete({
+        systemPrompt: "s",
+        userPrompt: "u",
+        model: "gemini-2.5-flash",
+        maxTokens: 100,
+        apiKey: "mock-google-test",
+        onToken: () => { /* ignore */ },
+      }),
+    ).rejects.toThrow(/Resource exhausted/);
+  });
+
+  it("does NOT silently include pre-error tokens", async () => {
+    programChunks([
+      'data: {"candidates":[{"content":{"parts":[{"text":"begin"}]}}]}\n\n',
+      'data: {"error":{"message":"Filtered for safety"}}\n\n',
+    ]);
+
+    const provider = new GoogleProvider(stubHttp);
+    const result = await provider.complete({
+      systemPrompt: "s",
+      userPrompt: "u",
+      model: "gemini-2.5-flash",
+      maxTokens: 100,
+      apiKey: "mock-google-test",
+      onToken: () => { /* ignore */ },
+    }).catch((e) => e);
+
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toMatch(/Filtered for safety/);
+  });
+});
+
+describe("Ollama streaming — SSE error events", () => {
+  // Ollama's /v1/chat/completions endpoint is OpenAI-compatible; same shape.
+  it("rejects when an error chunk is received mid-stream", async () => {
+    programChunks([
+      'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+      'data: {"error":{"message":"Model not found"}}\n\n',
+    ]);
+
+    const provider = new OllamaProvider(stubHttp);
+    await expect(
+      provider.complete({
+        systemPrompt: "s",
+        userPrompt: "u",
+        model: "llama3.2",
+        maxTokens: 100,
+        endpoint: "http://localhost:11434",
+        onToken: () => { /* ignore */ },
+      }),
+    ).rejects.toThrow(/Model not found/);
+  });
+
+  it("rejects on bare-string Ollama error shape", async () => {
+    // Ollama also sometimes emits `{"error": "..."}` (string, not object)
+    programChunks([
+      'data: {"error":"context deadline exceeded"}\n\n',
+    ]);
+
+    const provider = new OllamaProvider(stubHttp);
+    await expect(
+      provider.complete({
+        systemPrompt: "s",
+        userPrompt: "u",
+        model: "llama3.2",
+        maxTokens: 100,
+        endpoint: "http://localhost:11434",
+        onToken: () => { /* ignore */ },
+      }),
+    ).rejects.toThrow(/context deadline exceeded/);
+  });
+});
+
+describe("Streaming error events — common contract", () => {
+  it("error message includes the provider name for triage", async () => {
+    programChunks([
+      'data: {"type":"error","error":{"type":"x","message":"y"}}\n\n',
+    ]);
+    const provider = new AnthropicProvider(stubHttp);
+    const err = await provider.complete({
+      systemPrompt: "s",
+      userPrompt: "u",
+      model: "claude-sonnet-4-6",
+      maxTokens: 100,
+      apiKey: "mock-anthropic-test",
+      onToken: () => { /* required to take streaming path */ },
+    }).catch((e) => e);
+    expect((err as Error).message.toLowerCase()).toContain("anthropic");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,17 +24,17 @@ export default defineConfig({
         "src/logger.ts",
       ],
       thresholds: {
-        // Global floor — ratchet only up. Every PR that adds tests should
-        // raise these toward 90% as actual coverage rises. The bulk of the
-        // gap to 90% is in the four providers' streaming SSE paths; closing
-        // audit issue #41 brings global coverage to ~90% in one shot.
+        // Global floor — ratchet only up.
         //
-        // After issue #18 (LLM timeout): lines 82.19%, statements 81.56%,
-        // functions 91.56%, branches 69.60%.
-        lines: 82,
-        statements: 81,
-        functions: 91,
-        branches: 69,
+        // After issue #17 (SSE error events): lines 90.93%, statements 89.77%,
+        // functions 96.38%, branches 77.54%. The streaming-errors tests
+        // exercised the previously-uncovered streaming SSE paths across all
+        // four providers, delivering the global-coverage jump that audit
+        // issue #41 was scoped for.
+        lines: 90,
+        statements: 89,
+        functions: 96,
+        branches: 77,
 
         // Per-file ratchets — each module locked at or just below its current
         // coverage so it cannot regress. When tests rise, raise the lock here


### PR DESCRIPTION
Closes #17.

## Problem

Each streaming provider's SSE parser had a `try { JSON.parse } catch { /* skip */ }` block that swallowed any well-formed event whose shape it didn't explicitly recognize — including upstream `error` events. A streaming call that errored mid-flight returned empty text with status 200, indistinguishable from a successful empty completion.

## Fix

Per-provider error event detection inside the SSE parser:
| Provider | Event shape detected |
|---|---|
| Anthropic | \`event.type === \"error\"\` → captures msg + type |
| OpenAI | \`event.error\` object → captures msg + type |
| Google | \`event.error\` object → captures msg + status |
| Ollama | \`event.error\` (string OR object — both shapes seen in the wild) |

Captured into a closure variable rather than thrown directly because `streamRequest`'s `onChunk` wraps consumer throws to keep the stream alive. After `streamRequest` resolves, providers throw the captured error — which means **partial pre-error tokens never surface as a successful CompletionResponse**.

Also extended each provider's streaming-fallback catch to re-throw \`<Provider> streaming error\` and \`TimeoutError\` instead of falling through to the non-streaming `httpFn` path. Without this fix the streaming error was silently retried via the non-streaming API, defeating the whole point.

## Tests

10 new tests in \`test/providers/streaming-errors.test.ts\`, two per provider plus a common-contract test:
- Mid-stream error event causes rejection with the upstream message
- Pre-error tokens NOT silently included as a successful result
- Error message includes provider name + error type for triage
- Ollama: covers both bare-string and object error shapes

## Coverage windfall

The streaming-errors tests exercised previously-untested code paths in all four providers, lifting global coverage:

| Metric | Before | After |
|---|---|---|
| Lines | 82.19% | **90.93%** |
| Statements | 81.56% | 89.77% |
| Functions | 91.56% | 96.38% |
| Branches | 69.60% | 77.54% |

This delivers the global-coverage jump that audit issue #41 was scoped for, in this PR. Thresholds ratcheted: vitest lines 82→90, statements 81→89, functions 91→96, branches 69→77; \`.munitor.yml\` min_instruction 82→90.

## Test plan
- [x] \`npm run check\` passes locally (477 tests, 90.93% lines, all gates green)
- [ ] CI pr-checks workflow passes
- [ ] In Books vault: trigger a real Anthropic call with very low \`maxTokens\` to provoke an early error → review note shows \"Anthropic streaming error [...]:\" instead of \"0 words generated\"