### PR TITLE
feat: preserve whitespace in LLM responses (#16)

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -389,7 +389,7 @@ export class AnthropicProvider implements LLMService {
         (block: Record<string, unknown>) => block.type === "text",
       );
       if (textBlock && typeof textBlock.text === "string") {
-        text = textBlock.text.trim();
+        text = textBlock.text;
       }
     }
 

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -328,7 +328,7 @@ export class GoogleProvider implements LLMService {
           (part: Record<string, unknown>) => typeof part.text === "string",
         );
         if (textPart) {
-          text = textPart.text.trim();
+          text = textPart.text;
         }
       }
     }

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -339,7 +339,7 @@ export class OllamaProvider implements LLMService {
     if (data && Array.isArray(data.choices) && data.choices.length > 0) {
       const choice = data.choices[0];
       if (choice.message && typeof choice.message.content === "string") {
-        text = choice.message.content.trim();
+        text = choice.message.content;
       }
     }
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -309,7 +309,7 @@ export class OpenAIProvider implements LLMService {
     if (data && Array.isArray(data.choices) && data.choices.length > 0) {
       const choice = data.choices[0];
       if (choice.message && typeof choice.message.content === "string") {
-        text = choice.message.content.trim();
+        text = choice.message.content;
       }
     }
 

--- a/test/providers/anthropic.test.ts
+++ b/test/providers/anthropic.test.ts
@@ -296,6 +296,18 @@ describe("AnthropicProvider", () => {
       expect(body.model).toBe("claude-opus-4-6");
     });
 
+    it("preserves leading and trailing whitespace in the response (#16)", async () => {
+      // Authors rely on intentional whitespace as part of vertical rhythm.
+      // Provider parseResponse must not silently .trim() the model output.
+      const responseText = anthropicResponse("\n  the door slammed.  \n");
+      const { fn } = mockHttp({ text: responseText });
+      const provider = new AnthropicProvider(fn);
+
+      const result = await provider.complete(makeRequest());
+
+      expect(result.text).toBe("\n  the door slammed.  \n");
+    });
+
     it("throws on 400 response with error message", async () => {
       const errorResponse = JSON.stringify({
         error: { type: "invalid_request_error", message: "max_tokens must be positive" },


### PR DESCRIPTION
Closes #16.

Removes `.trim()` from the non-streaming `parseResponse` path in all four providers (anthropic, openai, google, ollama). Streaming paths accumulate raw chunks and are unaffected.

Authors rely on intentional whitespace as part of vertical rhythm. Models that emit a leading `\n` (especially Opus) are doing so on purpose to mark a passage start, and `assembler.ts` uses that whitespace at the splice point. Stripping it produced visually jammed paragraphs.

## Test plan

- [x] New test in `anthropic.test.ts` asserts whitespace passthrough.
- [x] `npm run check` green: 523 tests pass, all coverage thresholds met.